### PR TITLE
fix: (weapon-upgrade) adjust recommended parameters for cylinder upgrade

### DIFF
--- a/src/views/WeaponUpgradeSimulator.vue
+++ b/src/views/WeaponUpgradeSimulator.vue
@@ -865,7 +865,7 @@ const quickPresets: QuickPreset[] = [
         weaponCategories: ["cylinder", "shield_cylinder"],
         abilityWeights: {
             lance_piercing: 70,
-            all_alchemy_damage: 4,
+            all_alchemy_damage: 1,
         },
     },
     // 鍊金系 - 大傷優先
@@ -902,6 +902,7 @@ const quickPresets: QuickPreset[] = [
         weaponCategories: ["cylinder", "shield_cylinder"],
         abilityWeights: {
             fire_alchemy_damage: 1,
+            all_alchemy_damage: 3,
         },
     },
     // 鋼瓶 - 水元素
@@ -913,6 +914,7 @@ const quickPresets: QuickPreset[] = [
         weaponCategories: ["cylinder", "shield_cylinder"],
         abilityWeights: {
             water_alchemy_damage: 1,
+            all_alchemy_damage: 3,
         },
     },
     // 鋼瓶 - 風元素
@@ -924,6 +926,7 @@ const quickPresets: QuickPreset[] = [
         weaponCategories: ["cylinder", "shield_cylinder"],
         abilityWeights: {
             wind_alchemy_damage: 1,
+            all_alchemy_damage: 3,
         },
     },
     // 鋼瓶 - 土元素
@@ -935,6 +938,7 @@ const quickPresets: QuickPreset[] = [
         weaponCategories: ["cylinder", "shield_cylinder"],
         abilityWeights: {
             earth_alchemy_damage: 1,
+            all_alchemy_damage: 3,
         },
     },
     // 盾牌鋼瓶 - 加入 PD


### PR DESCRIPTION
原本四元素（Fire, Water, Earth, Wind）的權重設定過高，導致系統在推薦「銳利改 (Sharpness Upgrade)」的路徑下，仍然會錯誤地優先選擇四元素路徑。經檢查後發現其他元素也存在類似的權重失衡問題。

The weight for the four elements was previously set too high, causing the recommendation system to prioritize elemental paths even when a "lance_piercing Upgrade" was preferred. Further investigation revealed similar imbalances across other elemental parameters.

Changes / 修改內容
調整元素權重參數：調低四元素及相關元素的權重值，確保推薦邏輯符合預期。

Refined element weight parameters: Lowered the weights for the four elements and related attributes to ensure recommendation logic aligns with the intended priority (e.g., lance_piercing).

# lance piercing  

before: ( select all alchemy method at  first method)
lance_piercing: 70,
all_alchemy_damage: 4,

after:
lance_piercing: 70,
all_alchemy_damage: 1,

# single alchemy damage

before: ( miss first method)

fire_alchemy_damage: 1,

after:

fire_alchemy_damage: 1,
all_alchemy_damage: 3,